### PR TITLE
Give plugins access to node.Close()

### DIFF
--- a/core/interface.go
+++ b/core/interface.go
@@ -171,6 +171,7 @@ type Node interface {
 	WSEndpoint() string
 	ResolvePath(x string) string
 	Attach() (Client, error)
+	Close() error
 }
 
 type Client interface {


### PR DESCRIPTION
Prior to this update, plugins could shutdown Geth by panicking, but
had no mechanism to shutdown cleanly. Simply exposing the node.Close()
function (which already exists on the Node struct), plugins should
be able to initiate a clean shutdown.

In general, Plugins should make sparing use of this capability, but
in light of the fact that they were able to do unclean shutdowns
via a panic(), we can't avoid allowing them to stop Geth, and allowing
them to do so cleanly seems better than relying on panics.