### PR TITLE
add GetContractCode

### DIFF
--- a/core/interface.go
+++ b/core/interface.go
@@ -57,6 +57,7 @@ type Backend interface {
 
 	GetTrie(hash Hash) (Trie, error)
 	GetAccountTrie(stateRoot Hash, account Address) (Trie, error)
+	GetContractCode(Hash) ([]byte, error)
 
 	// ChainConfig() *params.ChainConfig
 	// Engine() consensus.Engine


### PR DESCRIPTION
This exposes the contract code stored in the state database (`StateUpdate` hooks provide code for newly added contracts, but this doesn't include built-in contracts present at genesis).

The backend method is exposed in https://github.com/openrelayxyz/plugeth/pull/84